### PR TITLE
chore: update CI to run on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         run: npm run build
 
       - name: Upload coverage reports
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '24.x'
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage/lcov.info


### PR DESCRIPTION
Update GitHub Actions CI configuration to use Node.js 24 instead of 20.